### PR TITLE
HTTP status related work moved to controller.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-<<<<<<< HEAD
-"# pub-quiz-server" 
+"# pub-quiz-server"

--- a/src/main/java/is/hi/hbv601/pubquiz/controller/RESTResponseController.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/controller/RESTResponseController.java
@@ -2,7 +2,7 @@
  * RESTResponseController reacts to JSON requests.
  * 
  * @author Eiður Örn Gunnarsson eog26@hi.is
- * @date 11. feb. 2018
+ * @date 15. feb. 2018
  */
 
 package is.hi.hbv601.pubquiz.controller;
@@ -16,9 +16,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import is.hi.hbv601.pubquiz.model.Answer;
 import is.hi.hbv601.pubquiz.model.FetchQuestionWrapper;
 import is.hi.hbv601.pubquiz.model.Question;
+import is.hi.hbv601.pubquiz.model.ReceivedAnswer;
 import is.hi.hbv601.pubquiz.model.Team;
 import is.hi.hbv601.pubquiz.service.interfaces.AnswerServiceInt;
 import is.hi.hbv601.pubquiz.service.interfaces.QuestionServiceInt;
@@ -42,10 +42,14 @@ public class RESTResponseController {
      * @param jsonString The JSON string received.
      * @return HTTP status of 200 if successful, 400 if the request was invalid.
      */
-    @RequestMapping(value = "/answer", method = RequestMethod.POST, produces = "application/json")
-    public @ResponseBody ResponseEntity<HttpStatus> saveAnswer(@RequestBody Answer jsonString) {
+    @RequestMapping(value = "/api/answer", method = RequestMethod.POST, produces = "application/json")
+    public @ResponseBody ResponseEntity<HttpStatus> saveAnswer(@RequestBody ReceivedAnswer jsonString) {
     	System.out.println(jsonString);
-        return answerService.checkData(jsonString);
+        boolean result = answerService.saveAnswer(jsonString);
+        if(result) {
+        	new ResponseEntity<>(HttpStatus.OK);
+        }
+    	return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
     
     /**
@@ -54,7 +58,7 @@ public class RESTResponseController {
      * @param jsonString The JSON string received.
      * @return Question related to data given.
      */
-    @RequestMapping(value = "/question", method = RequestMethod.POST, produces = "application/json")
+    @RequestMapping(value = "/api/question", method = RequestMethod.POST, produces = "application/json")
     public @ResponseBody Question fetchQuestion(@RequestBody FetchQuestionWrapper jsonString) {
     	System.out.println(jsonString);
         return questionService.getQuestionFromQuiz(jsonString);
@@ -66,10 +70,14 @@ public class RESTResponseController {
      * @param jsonString The JSON string received.
      * @return HTTP status of 201 if successful and a relevant JSON object, 403 if the team already exists.
      */
-    @RequestMapping(value = "/register_team", method = RequestMethod.POST, produces = "application/json")
+    @RequestMapping(value = "/api/register_team", method = RequestMethod.POST, produces = "application/json")
     public @ResponseBody ResponseEntity<?> registerTeam(@RequestBody Team jsonString) {
     	System.out.println(jsonString);
-        return teamService.registerTeam(jsonString);
+    	String resultString = teamService.registerTeam(jsonString);
+    	if (resultString.isEmpty()) {
+    		return new ResponseEntity<HttpStatus>(HttpStatus.FORBIDDEN);
+		}
+    	return new ResponseEntity<String>(resultString, HttpStatus.CREATED);
     }
     
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/model/ReceivedAnswer.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/model/ReceivedAnswer.java
@@ -1,0 +1,35 @@
+/**
+ * Model object for the received answer data.
+ * 
+ * @author Eiður Örn Gunnarsson eog26@hi.is
+ * @date 15. feb. 2018
+ */
+package is.hi.hbv601.pubquiz.model;
+
+public class ReceivedAnswer {
+	private long team_id;
+	private long question_id;
+	private String answer;
+	
+	public ReceivedAnswer(long team_id, long question_id, String answer) {
+		this.team_id = team_id;
+		this.question_id = question_id;
+		this.answer = answer;
+	}
+	
+	public ReceivedAnswer() {
+	}
+	
+	public long getTeam_id() {
+		return team_id;
+	}
+
+	public long getQuestion_id() {
+		return question_id;
+	}
+
+	public String getAnswer() {
+		return answer;
+	}
+
+}

--- a/src/main/java/is/hi/hbv601/pubquiz/service/AnswerService.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/AnswerService.java
@@ -2,28 +2,26 @@
  * AnswerSerivce is an implementation of the AnswerServiceInt
  * 
  * @author Eiður Örn Gunnarsson eog26@hi.is
- * @date 10. feb. 2018
+ * @date 15. feb. 2018
  */
 
 package is.hi.hbv601.pubquiz.service;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import is.hi.hbv601.pubquiz.model.Answer;
+import is.hi.hbv601.pubquiz.model.ReceivedAnswer;
 import is.hi.hbv601.pubquiz.service.interfaces.AnswerServiceInt;
 
 @Service
 public class AnswerService implements AnswerServiceInt{
-	public ResponseEntity<HttpStatus> checkData(Answer data) {
+	public boolean saveAnswer(ReceivedAnswer data) {
 		boolean valid = true;
 		//TODO: Check if the JSON string is correct. 
 		if(valid) {
 			saveData(data);
-			return new ResponseEntity<>(HttpStatus.OK);
+			return true;
 		}
-		return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		return false;
 	}
 	
 	/**
@@ -31,7 +29,7 @@ public class AnswerService implements AnswerServiceInt{
 	 * 
 	 * @param data The data to be saved.
 	 */
-	private void saveData(Answer data) {
+	private void saveData(ReceivedAnswer data) {
 		//TODO: Save into database.
 		System.out.println("====================");
 		System.out.println(data.getAnswer());

--- a/src/main/java/is/hi/hbv601/pubquiz/service/TeamService.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/TeamService.java
@@ -7,8 +7,6 @@
 
 package is.hi.hbv601.pubquiz.service;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,16 +18,17 @@ import is.hi.hbv601.pubquiz.service.interfaces.TeamServiceInt;
 
 @Service
 public class TeamService implements TeamServiceInt{
-	public ResponseEntity<?> registerTeam(Team t){
+	public String registerTeam(Team t){
+		String jsonString = "";
 		boolean exists = teamExists(t);
 		if(exists) {
-			return new ResponseEntity<HttpStatus>(HttpStatus.FORBIDDEN);
+			return jsonString;
 		}
 		
 		NewTeamReturn registeredTeam = createRegisteredTeam(t);
 		saveData(registeredTeam);
 		
-		String jsonString = "";
+		
 		try {
 			jsonString = convertToJsonString(registeredTeam);
 		} catch (JsonProcessingException e) {
@@ -37,7 +36,7 @@ public class TeamService implements TeamServiceInt{
 			e.printStackTrace();
 		}
 		
-		return new ResponseEntity<String>(jsonString, HttpStatus.CREATED);
+		return jsonString;
 	}
 	
 	/**

--- a/src/main/java/is/hi/hbv601/pubquiz/service/interfaces/AnswerServiceInt.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/interfaces/AnswerServiceInt.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import is.hi.hbv601.pubquiz.model.Answer;
+import is.hi.hbv601.pubquiz.model.ReceivedAnswer;
 
 public interface AnswerServiceInt {
 	
@@ -18,8 +19,8 @@ public interface AnswerServiceInt {
 	 * Checks whether the data is valid and if so saves it.
 	 * 
 	 * @param data The data to be checked.
-	 * @return HTTP status of 200 if successful, 400 if the data was invalid.
+	 * @return True if successful; false if unsuccessful.
 	 */
-	public ResponseEntity<HttpStatus> checkData(Answer data);
+	public boolean saveAnswer(ReceivedAnswer data);
 
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/service/interfaces/TeamServiceInt.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/interfaces/TeamServiceInt.java
@@ -8,8 +8,6 @@
 
 package is.hi.hbv601.pubquiz.service.interfaces;
 
-import org.springframework.http.ResponseEntity;
-
 import is.hi.hbv601.pubquiz.model.Team;
 
 public interface TeamServiceInt {
@@ -18,8 +16,7 @@ public interface TeamServiceInt {
 	 * Checks whether the team exists already, if it doesn't it registers the team.
 	 * 
 	 * @param t The team to register.
-	 * @return HTTP status of 201 if successful and a relevant JSON object; HTTP status 
-	 * 403 if the team already exists.
+	 * @return Relevant JSON string if successful; Empty JSON string if it fails.
 	 */
-	public ResponseEntity<?> registerTeam(Team t);
+	public String registerTeam(Team t);
 }


### PR DESCRIPTION
HTTP statuses have been removed from the services and moved over to the
controller, "/api" has been placed in front of URL calls and a separate
model class for received answers without an ID has been created and
replaced the Answer model class in appropriate places.