### PR TITLE
Create re-usable questions user story has been completed.

### DIFF
--- a/src/main/java/is/hi/hbv601/pubquiz/controller/QuizController.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/controller/QuizController.java
@@ -1,12 +1,12 @@
 /**
  * QuizController handles requests concerning quizzes.
  * 
+ * @author Eiður Örn Gunnarsson eog26@hi.is
  * @author Viktor Alex Brynjarsson vab18@hi.is
- * @date 13. feb. 2018
+ * @date 22. feb. 2018
  */
 package is.hi.hbv601.pubquiz.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -22,9 +22,10 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
 
 import is.hi.hbv601.pubquiz.model.Question;
+import is.hi.hbv601.pubquiz.model.QuestionsInQuiz;
 import is.hi.hbv601.pubquiz.model.Quiz;
-import is.hi.hbv601.pubquiz.repository.QuestionRepository;
 import is.hi.hbv601.pubquiz.service.QuestionService;
+import is.hi.hbv601.pubquiz.service.QuestionsInQuizService;
 import is.hi.hbv601.pubquiz.service.QuizService;
 
 @Controller
@@ -36,6 +37,9 @@ public class QuizController
 	
 	@Autowired
 	QuestionService questionService;
+	
+	@Autowired
+	QuestionsInQuizService questionsInQuizService;
 	
 	/**
 	 * Show a list of quizzes
@@ -155,11 +159,14 @@ public class QuizController
     	
     	if (!errors.hasErrors())
     	{
-    		System.out.println(question.getQuestion());
-    		System.out.println(question.getId());
-    		System.out.println(question.getIsPrivate());
-        	questionService.addQuestion(question);
-        	
+    		if(!questionService.doesQuestionExist(question))
+    		{
+    			questionService.addQuestion(question);
+    			//TODO: Alert user if question already exists, maybe offer to use it?
+    		}
+        	Quiz quiz = quizService.findQuiz(quizId);
+        	QuestionsInQuiz link = new QuestionsInQuiz(quiz,question);
+        	questionsInQuizService.addQuestion(link);
         	return new ModelAndView("redirect:/quiz/" + quizId);
     	}
 
@@ -205,6 +212,9 @@ public class QuizController
     	
     	// TODO: maybe check if question is part of quiz
     	
+    	questionsInQuizService.deleteLink(quizId, questionId);
+    	
+    	// TODO: Check who may actually delete the question (can only be done when we have authentication)
     	questionService.deleteQuestion(questionId);
     	
     	return new ModelAndView("redirect:/quiz/" + quizId);

--- a/src/main/java/is/hi/hbv601/pubquiz/controller/QuizController.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/controller/QuizController.java
@@ -6,6 +6,9 @@
  */
 package is.hi.hbv601.pubquiz.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -128,13 +131,12 @@ public class QuizController
     		Model model) {
     	
     	Quiz quiz = quizService.findQuiz(quizId);
-    	
     	Question q = new Question();
     	q.setQuiz(quiz);
     	
     	model.addAttribute("newQuestion", q);
     	model.addAttribute("quiz", quiz);
-
+    	
     	return new ModelAndView("question/form");
     }
 
@@ -153,6 +155,9 @@ public class QuizController
     	
     	if (!errors.hasErrors())
     	{
+    		System.out.println(question.getQuestion());
+    		System.out.println(question.getId());
+    		System.out.println(question.getIsPrivate());
         	questionService.addQuestion(question);
         	
         	return new ModelAndView("redirect:/quiz/" + quizId);
@@ -161,6 +166,31 @@ public class QuizController
     	return new ModelAndView("question/form");
     }
 
+    /**
+     * Show form for adding a question that has already been created.
+     * @param quizId id of the quiz to which the question should be added
+     * @param model
+     * @return add created question form
+     */
+    @RequestMapping(value = "/{quizId}/addCreatedQuestion", method = RequestMethod.GET)
+    public ModelAndView quizAddCreatedQuestionForm(
+    		@PathVariable(value = "quizId") long quizId,
+    		Model model) {
+    	
+    	Quiz quiz = quizService.findQuiz(quizId);
+    	Question q = new Question();
+    	List<Question> publicQuestionList = questionService.getPublicQuestionList();
+    	List<Question> privateQuestionList = questionService.getPrivateQuestionList();
+    	q.setQuiz(quiz);
+    	
+    	model.addAttribute("newQuestion", q);
+    	model.addAttribute("quiz", quiz);
+    	model.addAttribute("publicList", publicQuestionList);
+    	model.addAttribute("privateList", privateQuestionList);
+    	
+    	return new ModelAndView("question/formForCreatedQuestion");
+    }
+    
     /**
      * Delete a quiz
      * @param quizId the id of the quiz to be deleted

--- a/src/main/java/is/hi/hbv601/pubquiz/model/Question.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/model/Question.java
@@ -37,6 +37,8 @@ public class Question {
     private long total_questions;
 
     private String question_type;
+    
+    private boolean isPrivate;
 
 	@ManyToOne
 	@JoinColumn(name = "quiz_id")
@@ -45,12 +47,13 @@ public class Question {
 	public Question() {
 	}
 
-	public Question(long id, String question, long question_number, long total_questions, String question_type) {
+	public Question(long id, String question, long question_number, long total_questions, String question_type, boolean isPrivate) {
 		this.id = id;
 		this.question = question;
 		this.question_number = question_number;
 		this.total_questions = total_questions;
 		this.question_type = question_type;
+		this.isPrivate = isPrivate;
 	}
 
 	public long getId()
@@ -103,6 +106,16 @@ public class Question {
 		this.question_type = question_type;
 	}
 
+	public boolean getIsPrivate() 
+	{
+		return this.isPrivate;
+	}
+	
+	public void setIsPrivate(boolean isPrivate)
+	{
+		this.isPrivate = isPrivate;
+	}
+	
 	public Quiz getQuiz()
 	{
 		return quiz;

--- a/src/main/java/is/hi/hbv601/pubquiz/model/Question.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/model/Question.java
@@ -125,4 +125,5 @@ public class Question {
 	{
 		this.quiz = quiz;
 	}
+
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/model/QuestionsInQuiz.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/model/QuestionsInQuiz.java
@@ -1,0 +1,65 @@
+/**
+ * Model object for the QuestionsInQuiz.
+ * 
+ * @author Eiður Örn Gunnarsson eog26@hi.is
+ * @date 22. feb. 2018
+ */
+
+package is.hi.hbv601.pubquiz.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.GenericGenerator;
+
+@Entity
+@Table(name = "QuestionsInQuiz")
+public class QuestionsInQuiz {
+	@Id
+	@GeneratedValue(generator = "increment")
+	@GenericGenerator(name = "increment", strategy = "increment")
+	private long id;
+	
+	@ManyToOne
+	@JoinColumn(name = "quiz_id")
+	private Quiz quiz;
+	
+	@ManyToOne
+	@JoinColumn(name = "question_id")
+	private Question question;
+
+
+	public QuestionsInQuiz() {
+		
+	}
+	
+	public QuestionsInQuiz(Quiz quiz, Question question) {
+		this.quiz = quiz;
+		this.question = question;
+	}
+
+	public Quiz getQuiz() {
+		return quiz;
+	}
+
+	public void setQuiz(Quiz quiz) {
+		this.quiz = quiz;
+	}
+
+	public Question getQuestion() {
+		return question;
+	}
+
+	public void setQuestion(Question question) {
+		this.question = question;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+}

--- a/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionRepository.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionRepository.java
@@ -42,4 +42,11 @@ public interface QuestionRepository
 	 * @return List of all questions that contain the search string within.
 	 */
 	List<Question> findByQuestionContainingIgnoreCaseAndIsPrivateFalse(String question);
+	
+	/**
+	 * Searches if the exact same question exists.
+	 * @param question The question that is being searched for.
+	 * @return The same question if it exists.
+	 */
+	long countByQuestion(String question);
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionRepository.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionRepository.java
@@ -5,6 +5,8 @@
  */
 package is.hi.hbv601.pubquiz.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,4 +29,17 @@ public interface QuestionRepository
 	 */
 	@Transactional
 	Long deleteById(Long id);
+	
+	/**
+	 * Fetches all questions that have been made public.
+	 * @return A list of all publicly available questions.
+	 */
+	List<Question> findByIsPrivateFalseOrderByQuestionAsc();
+	
+	/**
+	 * Searches all publicly available questions for given string.
+	 * @param question Is the string that's being used to search for within the question
+	 * @return List of all questions that contain the search string within.
+	 */
+	List<Question> findByQuestionContainingIgnoreCaseAndIsPrivateFalse(String question);
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionsInQuizRepository.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/repository/QuestionsInQuizRepository.java
@@ -1,0 +1,36 @@
+/**
+ * Interface for saving questions within quiz to the persistence layer.
+ * @author Eiður Örn Gunnarsson
+ * @date 22. feb. 2017
+ */
+package is.hi.hbv601.pubquiz.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import is.hi.hbv601.pubquiz.model.Question;
+import is.hi.hbv601.pubquiz.model.QuestionsInQuiz;
+
+public interface QuestionsInQuizRepository
+	extends JpaRepository<QuestionsInQuiz, Long>
+{
+	/**
+	 * Save a question to the repository
+	 * @param q The question to be saved
+	 */
+	@SuppressWarnings("unchecked")
+	QuestionsInQuiz save(QuestionsInQuiz q);
+	
+	/**
+	 * Deletes a row that links a question and a quiz together
+	 * 
+	 * @param quizId id of the quiz in question
+	 * @param questionId id of the question in question
+	 * @return id of the row that was deleted
+	 */
+	@Transactional
+	Long deleteByQuizIdAndQuestionId(Long quizId, Long questionId);
+
+}

--- a/src/main/java/is/hi/hbv601/pubquiz/service/QuestionService.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/QuestionService.java
@@ -7,6 +7,9 @@
 
 package is.hi.hbv601.pubquiz.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +30,7 @@ public class QuestionService implements QuestionServiceInt{
 			return getQuestion(w);
 		}	
 		// TODO: Consider how to handle if the data for fetching the question is not valid.
-		return new Question(0, "This request is not valid", 0, 0, "invalid");
+		return new Question(0, "This request is not valid", 0, 0, "invalid", false);
 	}
 	
 	/**
@@ -50,7 +53,7 @@ public class QuestionService implements QuestionServiceInt{
 	 */
 	private Question getQuestion(FetchQuestionWrapper w) {
 		// TODO: Fetch the question and return it.
-		Question q = new Question(0, "Are pancakes delicious?", 4, 10, "text");
+		Question q = new Question(0, "Are pancakes delicious?", 4, 10, "text",false);
 		System.out.println("====================");
 		System.out.println(q.getQuestion());
 		System.out.println("Returning Question");
@@ -76,5 +79,27 @@ public class QuestionService implements QuestionServiceInt{
 	public void deleteQuestion(long id)
 	{
 		questionRepository.delete(id);
+	}
+	
+	/**
+	 * Fetches the list of all user related private questions.
+	 * @return list of all private questions for appropriate user.
+	 */
+	public List<Question> getPrivateQuestionList()
+	{
+		//TODO: When login system is in place a query can be created and should be called here 
+		//for getting questions for related user.
+		List<Question> l = new ArrayList<Question>();
+		l.add(new Question(40,"Question generated in code for testing purposes",3,5,"text",true));
+    	return l;
+	}
+	
+	/**
+	 * Fetches the list of all publicly available questions
+	 * @return list of all public available questions
+	 */
+	public List<Question> getPublicQuestionList()
+	{
+		return questionRepository.findByIsPrivateFalseOrderByQuestionAsc();
 	}
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/service/QuestionService.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/QuestionService.java
@@ -10,6 +10,8 @@ package is.hi.hbv601.pubquiz.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.core.IsNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -101,5 +103,16 @@ public class QuestionService implements QuestionServiceInt{
 	public List<Question> getPublicQuestionList()
 	{
 		return questionRepository.findByIsPrivateFalseOrderByQuestionAsc();
+	}
+	
+	/**
+	 * Finds out whether the question that is given exists already or not.
+	 * 
+	 * @param question The question that is meant to be checked for.
+	 * @return true if question exists; False if it doesn't.
+	 */
+	public boolean doesQuestionExist(Question question)
+	{
+		return questionRepository.countByQuestion(question.getQuestion()) >= 1;
 	}
 }

--- a/src/main/java/is/hi/hbv601/pubquiz/service/QuestionsInQuizService.java
+++ b/src/main/java/is/hi/hbv601/pubquiz/service/QuestionsInQuizService.java
@@ -1,0 +1,41 @@
+/**
+ * QuestionsInQuizService is management for question related services.
+ * 
+ * @author Eiður Örn Gunnarsson eog26@hi.is
+ * @date 22. feb. 2018
+ */
+
+package is.hi.hbv601.pubquiz.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import is.hi.hbv601.pubquiz.model.QuestionsInQuiz;
+import is.hi.hbv601.pubquiz.repository.QuestionsInQuizRepository;
+
+@Service
+public class QuestionsInQuizService {
+	
+	@Autowired 
+	QuestionsInQuizRepository questionsInQuizRepository;
+	
+	/**
+	 * Add a link between the question for related quiz to the repository.
+	 * 
+	 * @param q The question to be added to the quiz
+	 */
+	public void addQuestion(QuestionsInQuiz q)
+	{
+		questionsInQuizRepository.save(q);
+	}
+	
+	/**
+	 * Deletes the link between the quiz and question
+	 * @param quizId id of quiz in question
+	 * @param questionId id of question
+	 */
+	public void deleteLink(Long quizId, Long questionId) 
+	{
+		questionsInQuizRepository.deleteByQuizIdAndQuestionId(quizId, questionId);
+	}
+}

--- a/src/main/resources/templates/heima.html
+++ b/src/main/resources/templates/heima.html
@@ -13,7 +13,7 @@
 	    	console.log("a");
 	    	var xhr = new XMLHttpRequest();
 	    	console.log("b");
-	    	var url = "http://localhost:8080/answer";
+	    	var url = "http://localhost:8080/api/answer";
 	    	xhr.open("POST", url, true);
 	    	xhr.setRequestHeader("Content-type", "application/json");
 	    	/*xhr.onreadystatechange = function () {
@@ -21,14 +21,14 @@
 	    	        var json = JSON.parse(xhr.responseText);
 	    	    }
 	    	};*/
-	    	var data = JSON.stringify({"id":23,"team_id":2,"question_id":5,"answer":"I work."});
+	    	var data = JSON.stringify({"team_id":2,"question_id":5,"answer":"I work."});
 	    	xhr.send(data);
 	    }
 	
 	    function getQuestion() {
 	    	document.getElementById("abc").innerHTML = "Javascript is dead. I say again javascript is dead.";
 	    	xhr = new XMLHttpRequest();
-	    	url = "http://localhost:8080/question";
+	    	url = "http://localhost:8080/api/question";
 	    	xhr.open("POST", url, true);
 	    	xhr.setRequestHeader("Content-type", "application/json");
 	    	data = JSON.stringify({"quiz_id":23,"question_number":2,"phone_id":"eede877b-7741-4dec-a6a4-3b7d9b06bc5c"});
@@ -38,7 +38,7 @@
 	    function registerTeam() {
 	    	document.getElementById("abc").innerHTML = "Javascript's team is on holiday. I say again the team is on holiday.";
 	    	xhr = new XMLHttpRequest();
-	    	url = "http://localhost:8080/register_team";
+	    	url = "http://localhost:8080/api/register_team";
 	    	xhr.open("POST", url, true);
 	    	xhr.setRequestHeader("Content-type", "application/json");
 	    	data = JSON.stringify({"id":49, "room_name":"Waffles","team_name":"Tveir á kantinum","phone_id":"eede877b-7741-4dec-a6a4-3b7d9b06bc5c"});

--- a/src/main/resources/templates/question/formForCreatedQuestion.html
+++ b/src/main/resources/templates/question/formForCreatedQuestion.html
@@ -12,16 +12,29 @@
 			<input type="hidden" th:field="*{total_questions}" />
 			<input type="hidden" th:field="*{quiz}" />
 			<div>
-				<label for="roomName">Númer spurningar</label>
+				<label for="question_number">Númer spurningar</label>
 				<input type="number" th:field="*{question_number}" />
 			</div>
 			<div>
-				<label for="startTime">Tegund spurningar</label>
+				<label for="question_type">Tegund spurningar</label>
 				<input type="text" th:field="*{question_type}" />
 			</div>
 			<div>
-				<label for="duration">Spurning</label>
-				<textarea rows="24" cols="80" th:field="*{question}"></textarea>
+				<label for="question">Spurning</label>
+				<select th:field="*{question}">
+					<th:block th:switch="${privateList.isEmpty()}">
+						<optgroup th:case="false" label="Persónulegar spurningar">
+		                  <th:block th:each="q : ${privateList}">
+		                      <option th:value="${q.question}" th:text="${q.question}"></option>
+		                  </th:block>
+	                  	</optgroup>
+	                </th:block>
+	                <optgroup label="Almennings spurningar">
+		            	<th:block th:each="q : ${publicList}">
+		                	<option th:value="${q.question}" th:text="${q.question}"></option>
+		                </th:block>
+	                </optgroup>
+                </select>
 			</div>
 			<div>
 				<label for="isPrivate">Sýnileiki (geta aðrir valið að nota þessa spurningu í framtíðinni í sínu quizi)</label>

--- a/src/main/resources/templates/quiz/show.html
+++ b/src/main/resources/templates/quiz/show.html
@@ -36,6 +36,7 @@
 			<button type="submit">Bæta við spurningu</button>
 		</form-->
 		<a th:href="@{'/quiz/' + ${quiz.id} + '/addQuestion'}">Ný spurning</a>
+		<a th:href="@{'/quiz/' + ${quiz.id} + '/addCreatedQuestion'}">Ný tilbúin spurning</a>
 		<a th:href="@{'/quiz/'}">Til baka í quiz lista</a>
 	</body>
 </html>


### PR DESCRIPTION
Private flag has been added to every question.
A new form for viewing questions that have already been created and are
addable to the quiz.
Modifications to classes to compensate for added flag and new queries
required have been added.
Set up for viewing private questions has been set up; Once user
identifier has been added to the DB a query can be created in the
repository and replace the hard coded in "private" question within the
QuestionService class. The function in question is called
"getPrivateQuestionList()", consider placing the user identifier or
object in as a parameter. TODO has been added in there as a reminder.